### PR TITLE
Remove delete from generated sql files

### DIFF
--- a/lib/sample_data_dump_postgres_data_store/gateway.rb
+++ b/lib/sample_data_dump_postgres_data_store/gateway.rb
@@ -185,10 +185,10 @@ module SampleDataDumpPostgresDataStore
         `echo "SELECT 'No rows to load'" >> #{sql_file_path}`
       else
         File.open(sql_file_path, 'w+') do |file|
-          table_name = table_configuration.qualified_table_name
-          file.puts "DELETE FROM #{table_name};"
           insert_columns = table_columns(table_configuration)
+          table_name = table_configuration.qualified_table_name
           columns_in_quotes = insert_columns.map { |col| "\"#{col}\"" }.join(', ')
+
           file.puts "INSERT INTO #{table_name} (#{columns_in_quotes})"
           file.puts 'VALUES'
           results.each_with_index do |result, index|

--- a/lib/sample_data_dump_postgres_data_store/gateway.rb
+++ b/lib/sample_data_dump_postgres_data_store/gateway.rb
@@ -36,7 +36,6 @@ module SampleDataDumpPostgresDataStore
       end
 
       sql = File.read(source_file_path)
-      puts "Load data #{source_file_path}"
       @postgresql_adapter.execute(sql)
       Dry::Monads::Success(true)
     end
@@ -60,7 +59,6 @@ module SampleDataDumpPostgresDataStore
 
     def wipe_table(table_configuration)
       qualified_table_name = table_configuration.qualified_table_name
-      puts "Wipe table #{qualified_table_name}"
       @postgresql_adapter.execute "DELETE FROM #{qualified_table_name} CASCADE"
       Dry::Monads::Success(true)
     end

--- a/lib/sample_data_dump_postgres_data_store/gateway.rb
+++ b/lib/sample_data_dump_postgres_data_store/gateway.rb
@@ -36,6 +36,7 @@ module SampleDataDumpPostgresDataStore
       end
 
       sql = File.read(source_file_path)
+      puts "Load data #{source_file_path}"
       @postgresql_adapter.execute(sql)
       Dry::Monads::Success(true)
     end
@@ -59,6 +60,7 @@ module SampleDataDumpPostgresDataStore
 
     def wipe_table(table_configuration)
       qualified_table_name = table_configuration.qualified_table_name
+      puts "Wipe table #{qualified_table_name}"
       @postgresql_adapter.execute "DELETE FROM #{qualified_table_name} CASCADE"
       Dry::Monads::Success(true)
     end

--- a/spec/lib/sample_data_dump_postgres_data_store/gateway_spec.rb
+++ b/spec/lib/sample_data_dump_postgres_data_store/gateway_spec.rb
@@ -49,8 +49,7 @@ module SampleDataDumpPostgresDataStore
       expect(postgresql_adapter).to receive(:execute).with(data_sql)
     end
     let(:expect_data_load_with_string) do
-      insert_sql = "DELETE FROM my_schema_name.my_table_name;\n" \
-                   "INSERT INTO my_schema_name.my_table_name (\"contact_given_name\")\n" \
+      insert_sql = "INSERT INTO my_schema_name.my_table_name (\"contact_given_name\")\n" \
                    "VALUES\n('lorem')\n"
       expect(postgresql_adapter).to receive(:execute).with(insert_sql)
     end
@@ -102,8 +101,7 @@ module SampleDataDumpPostgresDataStore
           expect(File.exist?(dump_to_local_file.value!)).to be true
           local_file_system_gateway.decompress_compressed_dump_file(table_configuration)
 
-          insert_sql = "DELETE FROM my_schema_name.my_table_name;\n" \
-                       "INSERT INTO my_schema_name.my_table_name (\"contact_given_name\")\n" \
+          insert_sql = "INSERT INTO my_schema_name.my_table_name (\"contact_given_name\")\n" \
                        "VALUES\n(1)\n"
           expect(postgresql_adapter).to receive(:execute).with(insert_sql)
           gateway.load_dump_file(table_configuration)
@@ -130,8 +128,7 @@ module SampleDataDumpPostgresDataStore
           expect(File.exist?(dump_to_local_file.value!)).to be true
           local_file_system_gateway.decompress_compressed_dump_file(table_configuration)
 
-          insert_sql = "DELETE FROM my_schema_name.my_table_name;\n" \
-                       "INSERT INTO my_schema_name.my_table_name (\"user\")\n" \
+          insert_sql = "INSERT INTO my_schema_name.my_table_name (\"user\")\n" \
                        "VALUES\n('bob')\n"
           expect(postgresql_adapter).to receive(:execute).with(insert_sql)
           gateway.load_dump_file(table_configuration)
@@ -158,8 +155,7 @@ module SampleDataDumpPostgresDataStore
           expect(File.exist?(dump_to_local_file.value!)).to be true
           local_file_system_gateway.decompress_compressed_dump_file(table_configuration)
 
-          insert_sql = "DELETE FROM my_schema_name.my_table_name;\n" \
-                       "INSERT INTO my_schema_name.my_table_name (\"contact_given_name\")\n" \
+          insert_sql = "INSERT INTO my_schema_name.my_table_name (\"contact_given_name\")\n" \
                        "VALUES\n(NULL)\n"
           expect(postgresql_adapter).to receive(:execute).with(insert_sql)
           gateway.load_dump_file(table_configuration)


### PR DESCRIPTION
Previously each generated `.sql` file would start with the following line:

```
DELETE FROM table-name;
```

That is unnecessary since we [wipe all tables clean](https://github.com/tricycle/sample_data_dump_postgres_data_store/blob/master/lib/sample_data_dump_postgres_data_store/gateway.rb#L60-L64) before loading any new data.